### PR TITLE
서버 푸시 알림 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,8 +63,10 @@ $RECYCLE.BIN/
 # End of https://www.toptal.com/developers/gitignore/api/macos,windows
 
 
+# Custom gitignore
 test.ipynb
 __pycache__/
 get_conv_sale.py
 sql.py
 flask_main.py
+keys/

--- a/push_notification.py
+++ b/push_notification.py
@@ -1,0 +1,40 @@
+import firebase_admin
+from firebase_admin import messaging
+from firebase_admin import credentials
+
+
+class PushNotificationModule:
+    def __init__(self) -> None:
+
+        # 초기화되면 Admin SDK를 사용하여 다음 유형의 작업을 수행
+        __cred = credentials.Certificate("keys/serviceAccountKey.json")
+        firebase_admin.initialize_app(__cred)
+
+    def send_push(*, title: str, body: str, verbose=False) -> bool:
+        try:
+            # 사용자에게 푸시알림을 전송하기 위해 topic을 이용
+            topic = "PyeonHaeng"
+
+            # See documentation on defining a message payload.
+            message = messaging.Message(
+                notification=messaging.Notification(title=title, body=body),
+                topic=topic,
+            )
+
+            # Send a message to devices subscribed to the combination of topics
+            # specified by the provided condition.
+            response = messaging.send(message)
+            # Response is a message ID string.
+            if verbose:
+                print("Successfully sent message:", response)
+        except Exception as error:
+            if verbose:
+                print(error)
+            return False
+        return True
+
+
+if __name__ == "__main__":
+    PushNotificationModule().send_push(
+        title="3월 제품 업데이트 두 번째 :)!", body="3월 제품 업데이트가 완료되었습니다!"
+    )

--- a/push_notification.py
+++ b/push_notification.py
@@ -10,7 +10,7 @@ class PushNotificationModule:
         __cred = credentials.Certificate("keys/serviceAccountKey.json")
         firebase_admin.initialize_app(__cred)
 
-    def send_push(*, title: str, body: str, verbose=False) -> bool:
+    def send_push(self, *, title: str, body: str, verbose=False) -> bool:
         try:
             # 사용자에게 푸시알림을 전송하기 위해 topic을 이용
             topic = "PyeonHaeng"


### PR DESCRIPTION
## 📌 PR 요약

### 🌱 작업한 내용

- 서버 푸시알림 구현
- merge하기 앞서
   - `discord`에 올려둔 Firebase Messaging 비공개 키값을 `keys`폴더에 넣어두셔야 합니다!
   - `sudo pip3 install firebase-admin` 적용해야 합니다.

### 🌱 PR 포인트

- 실행할 때 다음과 같이 코드를 작성하면 됩니다. 꼭 `argument label`을 작성해야 오류가 나지 않습니다!
```python
PushNotificationModule().send_push(title="3월 제품 업데이트", body="3월 제품 업데이트가 완료되었습니다!")
```

## 📸 스크린샷
|스크린샷|
|:--:|
|![Screen Recording 2023-02-27 at 11 13 19 PM](https://user-images.githubusercontent.com/57972338/221587276-10f5e4ab-ea95-4695-ba2a-fa3b9a80d43f.gif)|
